### PR TITLE
Fix concurrent-map-writes

### DIFF
--- a/data/commitTable/commitTable.go
+++ b/data/commitTable/commitTable.go
@@ -6,13 +6,15 @@ import (
 	"github.com/team-triage/triage/types"
 )
 
-var CommitHash map[int]types.CommitStore = make(map[int]types.CommitStore) // map where keys are offsets and 'ack/nack' is boolean
+var hash map[int]types.CommitStore = make(map[int]types.CommitStore) // map where keys are offsets and 'ack/nack' is boolean
+var CommitHash *types.SafeCommitHash = types.MakeSafeCommitHash(hash)
 
 func Delete(offset int) {
 	currentOffset := offset
 	for {
-		if _, ok := CommitHash[currentOffset]; ok {
-			delete(CommitHash, currentOffset)
+		if _, ok := CommitHash.Read(currentOffset); ok {
+			CommitHash.Delete(currentOffset)
+			// delete(CommitHash, currentOffset)
 			fmt.Printf("COMMIT TABLE: Deleting entry at offset %v\n", currentOffset)
 			currentOffset--
 		} else {

--- a/fetcher/consumer.go
+++ b/fetcher/consumer.go
@@ -43,27 +43,6 @@ func makeConsumer() *kafka.Consumer {
 }
 
 func consume(c *kafka.Consumer, topic string) {
-	// commented next 5 lines because we're running this from main.go, not the command line
-	// if len(os.Args) != 2 {
-	// 	fmt.Fprintf(os.Stderr, "Usage: %s <config-file-path>\n",
-	// 		os.Args[0])
-	// 	os.Exit(1)
-	// }
-
-	// configFile := "dev/tmp/devConfig.properties" // os.Args[1] hard-coding the relative file path for now, since we're running from main.go
-	// conf := ReadConfig(configFile)
-	// conf["group.id"] = "kafka-go-getting-started" // need to make this an environmental variable so all instances of a given deployment share the same group.id
-	// conf["auto.offset.reset"] = "earliest"        // policy for when triage "dies"
-	// conf["enable.auto.commit"] = "false"          // turned off for manual committing (see consumer.Commit() or consumer.CommitMessage())
-
-	// c, err := kafka.NewConsumer(&conf)
-
-	// if err != nil {
-	// 	fmt.Printf("Failed to create consumer: %s", err)
-	// 	os.Exit(1)
-	// }
-
-	// topic := "purchases" -- replaced with parameter
 	err := c.SubscribeTopics([]string{topic}, nil)
 	if err != nil {
 		fmt.Printf("Failed to subscribe: %s\n", err)
@@ -88,11 +67,9 @@ func consume(c *kafka.Consumer, topic string) {
 			}
 			messages.AppendMessage(ev) // writing event to channel
 			commitStore := types.CommitStore{Value: false, Message: ev}
-			commitTable.CommitHash[int(ev.TopicPartition.Offset)] = commitStore
-
+			commitTable.CommitHash.Write(int(ev.TopicPartition.Offset), commitStore)
 		}
 	}
-
 	c.Close()
 }
 

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -13,9 +13,9 @@ func Filter() {
 		ack := acknowledgements.GetMessage()
 		fmt.Printf("FILTER: Received message at offset %v with status %v\n", ack.Offset, ack.Status)
 		if ack.Status == 1 { // if ack, simply updated commitHash
-			if entry, ok := commitTable.CommitHash[ack.Offset]; ok {
+			if entry, ok := commitTable.CommitHash.Read(ack.Offset); ok {
 				entry.Value = true
-				commitTable.CommitHash[ack.Offset] = entry
+				commitTable.CommitHash.Write(ack.Offset, entry)
 			}
 		} else {
 			deadLetters.AppendMessage(ack)

--- a/reaper/reaper.go
+++ b/reaper/reaper.go
@@ -13,9 +13,9 @@ func Reap() {
 		fmt.Printf("REAPER: Got a dead letter: %v \n", string(ack.Event.Value))
 		// ^ is an abstraction for writing to DynamoDB
 		// AFTER response from DynamoDB
-		if entry, ok := commitTable.CommitHash[ack.Offset]; ok {
+		if entry, ok := commitTable.CommitHash.Read(ack.Offset); ok {
 			entry.Value = true
-			commitTable.CommitHash[ack.Offset] = entry
+			commitTable.CommitHash.Write(ack.Offset, entry)
 		}
 	}
 }

--- a/types/safeCommitHash.go
+++ b/types/safeCommitHash.go
@@ -1,0 +1,46 @@
+package types
+
+import (
+	"sort"
+	"sync"
+
+	"golang.org/x/exp/maps"
+)
+
+func MakeSafeCommitHash(hash map[int]CommitStore) *SafeCommitHash {
+	return &SafeCommitHash{hash: hash}
+}
+
+type SafeCommitHash struct {
+	Mutex sync.Mutex
+	hash  map[int]CommitStore
+}
+
+func (s *SafeCommitHash) Write(key int, value CommitStore) {
+	s.Mutex.Lock()
+	s.hash[key] = value
+	s.Mutex.Unlock()
+}
+
+func (s *SafeCommitHash) Read(key int) (CommitStore, bool) {
+	s.Mutex.Lock()
+	if entry, ok := s.hash[key]; ok {
+		s.Mutex.Unlock()
+		return entry, true
+	}
+	s.Mutex.Unlock()
+	return CommitStore{}, false
+}
+
+// potential optimization: write a specific delete function (the for loop in commitCalculator.Delete) that only locks/unlocks once
+func (s *SafeCommitHash) Delete(key int) {
+	s.Mutex.Lock()
+	delete(s.hash, key)
+	s.Mutex.Unlock()
+}
+
+func (s *SafeCommitHash) GetOffsets() []int {
+	offsets := maps.Keys(s.hash)
+	sort.Ints(offsets)
+	return offsets
+}


### PR DESCRIPTION
Implemented concurrent-safe hash map under types/SafeCommitHash that utilizes sync.Mutex to lock the map.

Co-Authored-By: aashish-b <87250229+aashish-b@users.noreply.github.com>
Co-Authored-By: Aryan Binazir <65728619+aryan-binazir@users.noreply.github.com>
Co-Authored-By: Jordan Swartz <10202436+jordanLswartz@users.noreply.github.com>